### PR TITLE
feat(web): implement login page with token-based auth

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,2 @@
+VITE_API_BASE_URL=http://localhost:3000
+VITE_AUTH_STORAGE_KEY=lms_jwt

--- a/apps/web/src/components/Nav.tsx
+++ b/apps/web/src/components/Nav.tsx
@@ -1,0 +1,36 @@
+import { Link } from "react-router-dom";
+import { useAuth } from "../lib/auth";
+
+const Nav = () => {
+  const { user, logout } = useAuth();
+
+  return (
+    <nav className="flex items-center justify-between border-b border-gray-200 bg-white px-6 py-4 shadow-sm">
+      <Link to="/" className="text-lg font-semibold text-gray-900">
+        LMS
+      </Link>
+      <div className="flex items-center gap-4 text-sm">
+        {user ? (
+          <>
+            <span className="text-gray-700">{user.email}</span>
+            <button
+              onClick={logout}
+              className="rounded-md border border-transparent bg-gray-100 px-3 py-1 text-sm font-medium text-gray-700 transition hover:bg-gray-200"
+            >
+              Logout
+            </button>
+          </>
+        ) : (
+          <Link
+            to="/login"
+            className="rounded-md bg-indigo-600 px-3 py-1 text-sm font-medium text-white transition hover:bg-indigo-700"
+          >
+            Login
+          </Link>
+        )}
+      </div>
+    </nav>
+  );
+};
+
+export default Nav;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,0 +1,23 @@
+import axios from "axios";
+import { getStoredToken } from "./auth";
+
+const baseURL = (import.meta.env?.VITE_API_BASE_URL as string | undefined) ?? "";
+
+export const apiClient = axios.create({
+  baseURL,
+  withCredentials: true,
+});
+
+apiClient.interceptors.request.use((config) => {
+  const token = getStoredToken();
+  if (token) {
+    config.headers = config.headers ?? {};
+    config.headers.Authorization = `Bearer ${token}`;
+  } else if (config.headers?.Authorization) {
+    delete config.headers.Authorization;
+  }
+
+  return config;
+});
+
+export default apiClient;

--- a/apps/web/src/lib/auth.tsx
+++ b/apps/web/src/lib/auth.tsx
@@ -1,0 +1,177 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { apiClient } from "./api";
+
+export type AuthUser = {
+  id: string;
+  email: string;
+  [key: string]: unknown;
+};
+
+export type AuthContextValue = {
+  user: AuthUser | null;
+  token: string | null;
+  loading: boolean;
+  login: (email: string, password: string) => Promise<AuthUser>;
+  logout: () => void;
+};
+
+const AUTH_STORAGE_KEY =
+  (import.meta.env?.VITE_AUTH_STORAGE_KEY as string | undefined) ?? "lms_jwt";
+const API_BASE_URL =
+  (import.meta.env?.VITE_API_BASE_URL as string | undefined) ?? "";
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+const isBrowser = typeof window !== "undefined";
+
+export const getStoredToken = (): string | null => {
+  if (!isBrowser) {
+    return null;
+  }
+
+  try {
+    return window.localStorage.getItem(AUTH_STORAGE_KEY);
+  } catch (error) {
+    console.warn("Failed to read auth token from storage", error);
+    return null;
+  }
+};
+
+const storeToken = (token: string | null) => {
+  if (!isBrowser) {
+    return;
+  }
+
+  try {
+    if (token) {
+      window.localStorage.setItem(AUTH_STORAGE_KEY, token);
+    } else {
+      window.localStorage.removeItem(AUTH_STORAGE_KEY);
+    }
+  } catch (error) {
+    console.warn("Failed to persist auth token", error);
+  }
+};
+
+const fetchMe = async (): Promise<AuthUser> => {
+  const response = await apiClient.get("/me");
+  return response.data;
+};
+
+type AuthProviderProps = {
+  children?: React.ReactNode;
+};
+
+export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [token, setToken] = useState<string | null>(() => getStoredToken());
+  const [loading, setLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    let isActive = true;
+
+    const initialise = async () => {
+      if (!token) {
+        setLoading(false);
+        setUser(null);
+        return;
+      }
+
+      setLoading(true);
+      try {
+        const profile = await fetchMe();
+        if (isActive) {
+          setUser(profile);
+        }
+      } catch (error) {
+        if (isActive) {
+          setUser(null);
+          setToken(null);
+          storeToken(null);
+        }
+      } finally {
+        if (isActive) {
+          setLoading(false);
+        }
+      }
+    };
+
+    initialise();
+
+    return () => {
+      isActive = false;
+    };
+  }, [token]);
+
+  const login = useCallback(async (email: string, password: string) => {
+    setLoading(true);
+    try {
+      const response = await fetch(`${API_BASE_URL}/auth/login`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ email, password }),
+      });
+
+      if (!response.ok) {
+        const message = await response.text();
+        throw new Error(message || "Unable to login");
+      }
+
+      const payload = await response.json();
+      const accessToken = payload?.accessToken as string | undefined;
+
+      if (!accessToken) {
+        throw new Error("Login response did not include an access token");
+      }
+
+      storeToken(accessToken);
+      setToken(accessToken);
+
+      const profile = await fetchMe();
+      setUser(profile);
+      return profile;
+    } catch (error) {
+      storeToken(null);
+      setToken(null);
+      setUser(null);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const logout = useCallback(() => {
+    storeToken(null);
+    setToken(null);
+    setUser(null);
+  }, []);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({ user, token, loading, login, logout }),
+    [loading, login, logout, token, user]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = (): AuthContextValue => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+
+  return context;
+};
+
+export const clearStoredToken = () => storeToken(null);
+export const setStoredToken = (token: string | null) => storeToken(token);
+export const AUTH_TOKEN_STORAGE_KEY = AUTH_STORAGE_KEY;

--- a/apps/web/src/pages/Login.tsx
+++ b/apps/web/src/pages/Login.tsx
@@ -1,0 +1,104 @@
+import { FormEvent, useMemo, useState } from "react";
+import { Link, useLocation, useNavigate } from "react-router-dom";
+import { useAuth } from "../lib/auth";
+
+const Login = () => {
+  const { login, loading } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const nextPath = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    const next = params.get("next");
+    return next && next.startsWith("/") ? next : "/";
+  }, [location.search]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!email || !password) {
+      setError("Email and password are required");
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      await login(email, password);
+      navigate(nextPath || "/", { replace: true });
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Unable to sign in, please try again";
+      setError(message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12">
+      <div className="w-full max-w-md rounded-md border border-gray-200 bg-white p-8 shadow-sm">
+        <h1 className="mb-6 text-center text-2xl font-semibold text-gray-900">
+          Sign in to your account
+        </h1>
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div>
+            <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+              Email address
+            </label>
+            <input
+              id="email"
+              type="email"
+              autoComplete="email"
+              required
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="password"
+              className="block text-sm font-medium text-gray-700"
+            >
+              Password
+            </label>
+            <input
+              id="password"
+              type="password"
+              autoComplete="current-password"
+              required
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+            />
+          </div>
+
+          {(error || (loading && submitting)) && (
+            <div className="text-sm text-red-600" role="alert">
+              {error ?? "Signing you in..."}
+            </div>
+          )}
+
+          <button
+            type="submit"
+            disabled={submitting || loading}
+            className="flex w-full justify-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-indigo-300"
+          >
+            {submitting || loading ? "Signing in..." : "Sign in"}
+          </button>
+        </form>
+
+        <p className="mt-6 text-center text-sm text-gray-600">
+          Don't have an account? <Link className="text-indigo-600" to="/">Go back</Link>
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default Login;

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -1,0 +1,42 @@
+import { Navigate, Outlet, RouteObject, useLocation } from "react-router-dom";
+import Login from "./pages/Login";
+import { useAuth } from "./lib/auth";
+
+export const ProtectedRoute = () => {
+  const { user, loading } = useAuth();
+  const location = useLocation();
+
+  if (loading) {
+    return <div className="flex h-full items-center justify-center">Loading...</div>;
+  }
+
+  if (!user) {
+    const fullPath = `${location.pathname}${location.search}${location.hash}` || "/";
+    const search = new URLSearchParams({ next: fullPath }).toString();
+    return <Navigate to={`/login?${search}`} replace />;
+  }
+
+  return <Outlet />;
+};
+
+export const routes: RouteObject[] = [
+  {
+    element: <ProtectedRoute />,
+    children: [
+      {
+        path: "/",
+        element: <Outlet />,
+      },
+    ],
+  },
+  {
+    path: "/login",
+    element: <Login />,
+  },
+  {
+    path: "*",
+    element: <Navigate to="/" replace />,
+  },
+];
+
+export default routes;


### PR DESCRIPTION
## Summary
- add localStorage-backed auth context with login and logout handlers
- configure axios client to attach bearer token on each request
- introduce login page, protected route redirect, and navigation updates for authenticated state

## Testing
- not run (not available in environment)


------
https://chatgpt.com/codex/tasks/task_b_68e4f216ff9083298a8bdfc613cde058